### PR TITLE
Make test_server yaml use develop branch on non master.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
           pip install -r docs/requirements.txt
 
       - name: Install dependencies(using develop hed-python)
-        if: ${{ env.BRANCH_NAME != 'stable' || env.BRANCH_NAME != 'master' }}
+        if: ${{ env.BRANCH_NAME != 'stable' && env.BRANCH_NAME != 'master' }}
         run: |
           python -m pip install --upgrade pip
           pip install flake8

--- a/.github/workflows/test_server.yaml
+++ b/.github/workflows/test_server.yaml
@@ -5,6 +5,9 @@ on:
   push:
     branches: ["*"]
 
+env:
+  BRANCH_NAME: ${{ github.event.pull_request.base.ref || github.ref_name }}
+
 
 jobs:
   build:
@@ -21,10 +24,19 @@ jobs:
       - name: Make the script files executable
         run: chmod +x deploy_hed_dev/deploy.sh
 
-      - name: Execute a script from the repository
+
+      - name: Run deploy script (Stable)
+        if: ${{ env.BRANCH_NAME == 'master' || env.BRANCH_NAME == 'stable' }}
         run: | 
           cd deploy_hed_dev 
-          ./deploy.sh
+          ./deploy.sh master
+          cd ..
+
+      - name: Run deploy script (develop)
+        if: ${{ env.BRANCH_NAME != 'stable' && env.BRANCH_NAME != 'master' }}
+        run: | 
+          cd deploy_hed_dev 
+          ./deploy.sh develop
           cd ..
 
       - name: Set up Python ${{ matrix.python-version }}

--- a/tests/data/both_types_events.json
+++ b/tests/data/both_types_events.json
@@ -15,7 +15,7 @@
        "LongName": "Response time after stimulus",
        "Description": "Time from stimulus presentation until subject presses button",
        "Units": "ms",
-       "HED": "Duration/# ms, Action/Button press"
+       "HED": "Time-interval/# ms, Action/Button press"
    },
    "stim_file": {
        "LongName": "Stimulus file name",

--- a/tests/test_sidecars.py
+++ b/tests/test_sidecars.py
@@ -174,7 +174,7 @@ class Test(TestWebBase):
         hed_schema = load_schema_version('8.2.0')
         issues = json_sidecar.validate(hed_schema)
         self.assertIsInstance(issues, list)
-        self.assertEqual(len(issues), 37)
+        self.assertEqual(len(issues), 36)
 
     def test_sidecars_convert_to_short_valid(self):
         json_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data/bids_events.json')


### PR DESCRIPTION
Fix bug in ci.yaml, where it always used develop
Update test that broke from temporal validation change