### PR TITLE
Updated the behavior of the online tools for assembling HED

### DIFF
--- a/deploy_hed/Dockerfile
+++ b/deploy_hed/Dockerfile
@@ -28,7 +28,6 @@ RUN mkdir -p /var/log/hedtools && \
 # Copy the application code into the container
 COPY ./hedtools /root/hedtools/
 COPY ./hedtools/hedweb /root/hedtools/hedweb/
-#COPY ./hedtools/hedweb/runserver.py /root/
 
 # Set the PYTHONPATH environment variable to include /root/hedtools
 ENV PYTHONPATH="/root/hedtools"

--- a/deploy_hed_dev/Dockerfile
+++ b/deploy_hed_dev/Dockerfile
@@ -29,7 +29,6 @@ RUN mkdir -p /var/log/hedtools && \
 # Copy the application code into the container
 COPY ./hedtools /root/hedtools/
 COPY ./hedtools/hedweb /root/hedtools/hedweb/
-# COPY ./hedtools/hedweb/runserver.py /root/
 
 # Set the PYTHONPATH environment variable to include /root/hedtools
 ENV PYTHONPATH="/root/hedtools"

--- a/deploy_hed_dev/deploy.sh
+++ b/deploy_hed_dev/deploy.sh
@@ -112,6 +112,6 @@ echo "[INFO] Running new container..."
 run_new_container
 
 echo "[INFO] Cleaning up temporary directories..."
-# cleanup_directories
+cleanup_directories
 
 echo "[INFO] Deployment successful!"

--- a/hedweb/constants/base_constants.py
+++ b/hedweb/constants/base_constants.py
@@ -1,3 +1,4 @@
+APPEND_ASSEMBLED = 'append_assembled'
 CHECK_FOR_WARNINGS = 'check_for_warnings'
 
 COLUMN_COUNTS = 'column_counts'

--- a/hedweb/process_form.py
+++ b/hedweb/process_form.py
@@ -32,6 +32,7 @@ class ProcessForm:
         arguments = {
             bc.REQUEST_TYPE: bc.FROM_FORM,
             bc.COMMAND: request.form.get(bc.COMMAND_OPTION, ''),
+            bc.APPEND_ASSEMBLED: form_has_option(request.form, bc.APPEND_ASSEMBLED, 'on'),
             bc.CHECK_FOR_WARNINGS: form_has_option(request.form, bc.CHECK_FOR_WARNINGS, 'on'),
             bc.EXPAND_DEFS: form_has_option(request.form, bc.EXPAND_DEFS, 'on'),
             bc.INCLUDE_CONTEXT: form_has_option(request.form, bc.INCLUDE_CONTEXT, 'on'),

--- a/hedweb/templates/events.html
+++ b/hedweb/templates/events.html
@@ -12,7 +12,7 @@
     <form id="events_form" method="POST" enctype="multipart/form-data">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
         {{ create_actions(assemble=True,generate_sidecar=True,validate=True,remodel=True,search=True) }}
-        {{ create_options(check_for_warnings=True,expand_defs=True,include_context=True,include_summaries=True,replace_defs=True,remove_types_on=True) }}
+        {{ create_options(append_assembled=True,check_for_warnings=True,expand_defs=True,include_context=True,include_summaries=True,replace_defs=True,remove_types_on=True) }}
         <p>&nbsp;</p>
         <fieldset class="form-group">
             <legend>Input:</legend>

--- a/hedweb/templates/js/constants.js
+++ b/hedweb/templates/js/constants.js
@@ -1,4 +1,4 @@
-const DEFAULT_XML_URL = "https://raw.githubusercontent.com/hed-standard/hed-schemas/main/standard_schema/hedxml/HED8.2.0.xml";
+const DEFAULT_XML_URL = "https://raw.githubusercontent.com/hed-standard/hed-schemas/main/standard_schema/hedxml/HED8.3.0.xml";
 const EXCEL_FILE_EXTENSIONS = ['xlsx', 'xls'];
 const JSON_FILE_EXTENSIONS = ['json'];
 const OTHER_VERSION_OPTION = 'Other';

--- a/hedweb/templates/js/events-form.js
+++ b/hedweb/templates/js/events-form.js
@@ -103,6 +103,7 @@ function setEventsTable() {
 function setOptions() {
     let selectedElement = document.getElementById("process_actions");
     if (selectedElement.value === "validate") {
+        hideOption("append_assembled");
         showOption("check_for_warnings");
         hideOption("expand_defs");
         hideOption("include_context");
@@ -117,6 +118,7 @@ function setOptions() {
         $("#sidecar_input_section").show();
         $("#show_events_section").show();
     } else if (selectedElement.value === "assemble") {
+        showOption("append_assembled", true);
         hideOption("check_for_warnings");
         hideOption("expand_defs");
         showOption("include_context", true);
@@ -131,6 +133,7 @@ function setOptions() {
         $("#sidecar_input_section").show();
         $("#show_events_section").show();
     } else if (selectedElement.value === "generate_sidecar") {
+        hideOption("append_assembled");
         hideOption("check_for_warnings");
         hideOption("expand_defs");
         hideOption("include_context");
@@ -145,6 +148,7 @@ function setOptions() {
         $("#sidecar_input_section").hide();
         $("#show_events_section").show();
     } else if (selectedElement.value === "remodel") {
+        hideOption("append_assembled");
         hideOption("check_for_warnings");
         hideOption("expand_defs");
         hideOption("include_context");
@@ -159,6 +163,8 @@ function setOptions() {
         $("#sidecar_input_section").show();
         $("#show_events_section").show();
     }  else if (selectedElement.value === "search") {
+        showOption("append_assembled", true);
+        hideOption("append_assembled");
         hideOption("check_for_warnings");
         hideOption("expand_defs");
         showOption("include_context", true);

--- a/hedweb/templates/options.html
+++ b/hedweb/templates/options.html
@@ -1,48 +1,54 @@
-{% macro create_options(check_for_warnings=False,expand_defs=False,include_context=False,
+{% macro create_options(append_assembled=False,check_for_warnings=False,expand_defs=False,include_context=False,
 include_description_tags=False,include_summaries=False,replace_defs=False,remove_types_on=False) %}
     <fieldset id="options_section">
     <legend>Options:</legend>
         <div class="form-group" id="options">
+            {% if append_assembled %}
+                <span class="form-check form-switch" id="append_assembled_option" style="display: inline-block;">
+                    <input class="form-check-input" type="checkbox" name="append_assembled" id="append_assembled">
+                    <label class="form-check-label" for="append_assembled">Append assembled</label>
+                </span> &nbsp;&nbsp;
+            {% endif %}
             {% if check_for_warnings %}
                 <span class="form-check form-switch" id="check_for_warnings_option" style="display: inline-block;">
                     <input class="form-check-input" type="checkbox" name="check_for_warnings" id="check_for_warnings">
-                    <label class="form-check-label" for="check_for_warnings">Check for warnings</label>
-                </span> &nbsp; &nbsp;
+                    <label class="form-check-label" for="check_for_warnings">Check warnings</label>
+                </span> &nbsp;&nbsp;
             {% endif %}
             {% if expand_defs %}
                 <span class="form-check form-switch" id="expand_defs_option" style="display: inline-block;">
                     <input class="form-check-input" type="checkbox" name="expand_defs" id="expand_defs">
-                    <label class="form-check-label" for="expand_defs">Expand Def tags</label>
-                </span> &nbsp; &nbsp;
+                    <label class="form-check-label" for="expand_defs">Expand defs</label>
+                </span> &nbsp;&nbsp;
             {% endif %}
             {% if include_context %}
                 <span class="form-check form-switch" id="include_context_option" style="display: inline-block;">
                     <input class="form-check-input" type="checkbox" name="include_context" id="include_context">
-                    <label class="form-check-label" for="include_context">Include event context</label>
-                </span> &nbsp; &nbsp;
+                    <label class="form-check-label" for="include_context">Include context</label>
+                </span> &nbsp;&nbsp;
             {% endif %}
             {% if include_description_tags %}
                 <span class="form-check form-switch" id="include_description_tags_option" style="display: inline-block;">
                     <input class="form-check-input" type="checkbox" name="include_description_tags" id="include_description_tags">
-                    <label class="form-check-label" for="include_description_tags">Include Description tags</label>
-                </span> &nbsp; &nbsp;
+                    <label class="form-check-label" for="include_description_tags">Include description</label>
+                </span> &nbsp;&nbsp;
             {% endif %}
             {% if include_summaries %}
                 <span class="form-check form-switch" id="include_summaries_option" style="display: inline-block;">
                     <input class="form-check-input" type="checkbox" name="include_summaries" id="include_summaries">
                     <label class="form-check-label" for="include_summaries">Include summaries</label>
-                </span> &nbsp; &nbsp;
+                </span> &nbsp;&nbsp;
             {% endif %}
             {% if replace_defs %}
                 <span class="form-check form-switch" id="replace_defs_option" style="display: inline-block;">
                     <input class="form-check-input" type="checkbox" name="replace_defs" id="replace_defs">
-                    <label class="form-check-label" for="replace_defs">Replace Def tags</label>
-                </span> &nbsp; &nbsp;
+                    <label class="form-check-label" for="replace_defs">Replace defs</label>
+                </span> &nbsp;&nbsp;
             {% endif %}
             {% if remove_types_on %}
                 <span class="form-check form-switch" id="remove_types_on_option" style="display: inline-block;">
                     <input class="form-check-input" type="checkbox" name="remove_types_on" id="remove_types_on">
-                    <label class="form-check-label" for="remove_types_on">Remove Condition-variable and Task tags</label>
+                    <label class="form-check-label" for="remove_types_on">Remove condition and task</label>
                 </span>
             {% endif %}
         </div>


### PR DESCRIPTION
Updated the assemble operation for events to add the Append assembled operation.  If selected then the assembled HED is appended to the events.tsv as the "HedAssembled" column.  If is column already exists, it will be overwritten.  

If the option is not selected, then just the assembled HED strings with no header is returned.  The search operation is similarly updated. 

This change is in response to hed-standard/hed-schemas#283